### PR TITLE
Fix wrong admin links url

### DIFF
--- a/includes/notification.class.php
+++ b/includes/notification.class.php
@@ -86,7 +86,7 @@ abstract class TREMtrNotification {
 			'{date}'			=> $this->reservation->format_date( $this->reservation->reservation_date ).__( ' From ', 'tremtr' ).$this->reservation->format_time( $this->reservation->reservation_time_begin ).__( ' to ', 'tremtr' ).$this->reservation->format_time( $this->reservation->reservation_time_end ),
 			'{phone}'			=> $this->reservation->phone,
 			'{message}'			=> $this->reservation->message,
-			'{reservations_link}'	=> '<a href="' . admin_url( 'admin.php?page=tremtr-reservations&status=pending' ) . '">' . __( 'View pending reservations', 'tremtr' ) . '</a>',
+			'{reservations_link}'	=> '<a href="' . admin_url( 'edit.php?post_type=trem-reservation&status=pending' ) . '">' . __( 'View pending reservations', 'tremtr' ) . '</a>',
 			'{close_link}'		=> '<a href="' . admin_url( 'admin.php?page=tremtr-reservations&tremtr-quicklink=close&reservation=' . esc_attr( $this->reservation->ID ) ) . '">' . __( 'Reject this reservation', 'tremtr' ) . '</a>',
 			'{site_name}'		=> get_bloginfo( 'name' ),
 			'{site_link}'		=> '<a href="' . home_url( '/' ) . '">' . get_bloginfo( 'name' ) . '</a>',


### PR DESCRIPTION
"admin.php?page=tremtr-reservations&status=pending" {reservations_link} and "admin.php?page=tremtr-reservations&tremtr-quicklink=close&reservation=..." {close_link} throws insufficient permission screens. Also post_type is not tremtr-reservations but trem-reservation. Also all reservations are published by default, so status=pending filter doesn´t make sense here. Reject this reservation link also doesn´t work - no tremtr-quicklink parameter (not trem-quicklink either) is handled anywhere in code so it simply can´t work. May be it´s all from PRO version, but definitely don´t work in free version.